### PR TITLE
Add kubernetes-intro all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # kernel21_platform
 kernel21 Platform repository
+
+**При выполении работы сделано:**
+
+- Изучен процесс устновки minikube (плагины virtualbox, kvm2, none, docker) и kind.
+- Выяснены причинины восстановления подов после удаления. Coredns восстанавливается с помощью ReplicationController, остальные являются static pod'ами и восстанавливаются системной службой kublet (конфигуарции находятся в /etc/kubernetes/manifests).
+- Собран и запушен на docker hub образ согласно заданию. Создан yaml для pod с init контейнером.
+- Получен файл конфигурации hipster shop frontend, в результате аналига логов файл пофикшен и является рабочим.

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: kernel21/microservices-demo
+    name: frontend
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000" 
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: kernel21/microservices-demo
+    name: frontend
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels: 
+    app: web
+spec:
+  initContainers:
+    - name: init-web
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers:
+    - name: web
+      image: kernel21/kubernetes-intro
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+RUN adduser -D -u 1001 -g 'www' www
+RUN apk update && apk add nginx 
+RUN mkdir /app /run/nginx && \
+    chown -R www:www /run/nginx /var/lib/nginx /var/log/nginx /app
+ADD nginx.conf /etc/nginx/nginx.conf
+USER 1001
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]
+#ENTRYPOINT [ "nginx" ]
+#CMD [ "-c", "/etc/nginx/nginx.conf"]

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,41 @@
+worker_processes auto;
+pcre_jit on;
+error_log /var/log/nginx/error.log warn;
+include /etc/nginx/modules/*.conf;
+
+events {
+	worker_connections 1024;
+}
+
+http {
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	server_tokens off;
+	client_max_body_size 1m;
+	keepalive_timeout 65;
+	sendfile on;
+	tcp_nodelay on;
+	gzip_vary on;
+
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+			'$status $body_bytes_sent "$http_referer" '
+			'"$http_user_agent" "$http_x_forwarded_for"';
+	access_log /var/log/nginx/access.log main;
+
+	server {
+		listen                  8000;
+		server_name             localhost;
+		root                    /app;
+		client_max_body_size    32m;
+		error_page              500 502 503 504  /50x.html;
+
+		location = /50x.html {
+				root              /var/lib/nginx/html;
+		}
+
+		location / {
+			autoindex on;
+		}
+	}
+}


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [*] Основное ДЗ
 - [*] Задание со *

## В процессе сделано:
 - Изучен процесс устновки minikube (плагины virtualbox, kvm2, none, docker) и kind.
 - Выяснены причинины восстановления подов после удаления. Coredns восстанавливается с помощью ReplicationController, остальные являются static pod'ами и восстанавливаются системной службой kublet (конфигуарции находятся в /etc/kubernetes/manifests).
  - Собран и запушен на docker hub образ согласно заданию. Создан yaml для pod с init-контейнером.
  - Получен файл конфигурации hipster shop frontend, в результате аналига логов файл пофикшен и является рабочим.


## Как запустить проект:
- Запустить pod web-pod.yaml в кластере k8s kubectl apply -f web-pod.yaml
- Запустить pod hipster-shop frontend kubectl apply -f frontend-pod-healthy.yaml
## Как проверить работоспособность:
 - Запустить pod web-pod.yaml, пробросить порт 8000 kubectl port-forward --address 0.0.0.0 pod/web 8000:8000, перейти по ссылке http://localhost:8000
 - Проверить что pod hipster-shop frontend запустился без ошибок kubectl get pod frontend

## PR checklist:
 - [*] Выставлен label с темой домашнего задания
