### PR TITLE
Add hw12 files

### DIFF
--- a/kubernetes-storage/csi-crd_deploy.sh
+++ b/kubernetes-storage/csi-crd_deploy.sh
@@ -1,0 +1,11 @@
+# Change to the latest supported snapshotter version
+export SNAPSHOTTER_VERSION=v2.0.1
+
+# Apply VolumeSnapshot CRDs
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAPSHOTTER_VERSION/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAPSHOTTER_VERSION/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAPSHOTTER_VERSION/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+# Create snapshot controller
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAPSHOTTER_VERSION/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAPSHOTTER_VERSION/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml

--- a/kubernetes-storage/hw/csi-app.yaml
+++ b/kubernetes-storage/hw/csi-app.yaml
@@ -1,0 +1,15 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: storage-pod
+spec:
+  containers:
+    - name: my-frontend
+      image: nginx
+      volumeMounts:
+      - mountPath: "/data"
+        name: csi-volume
+  volumes:
+    - name: csi-volume
+      persistentVolumeClaim:
+        claimName: storage-pvc

--- a/kubernetes-storage/hw/csi-pvc.yaml
+++ b/kubernetes-storage/hw/csi-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-hostpath-sc

--- a/kubernetes-storage/hw/csi-restore.yaml
+++ b/kubernetes-storage/hw/csi-restore.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    name: csi-snapshot
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/hw/csi-snapshot.yaml
+++ b/kubernetes-storage/hw/csi-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: csi-snapshot
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source:
+    persistentVolumeClaimName: storage-pvc

--- a/kubernetes-storage/hw/csi-storageclass.yaml
+++ b/kubernetes-storage/hw/csi-storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/kubernetes-storage/iscsi/busybox-pv.yaml
+++ b/kubernetes-storage/iscsi/busybox-pv.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: iscsi-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  iscsi:
+     targetPortal: 192.168.33.254
+     iqn: iqn.2003-01.org.linux-iscsi.uiscsi.x8664:sn.d18ce9e73eff
+     lun: 0
+     fsType: 'ext4'
+     readOnly: false

--- a/kubernetes-storage/iscsi/busybox-pvc.yaml
+++ b/kubernetes-storage/iscsi/busybox-pvc.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: myclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/iscsi/busybox.yaml
+++ b/kubernetes-storage/iscsi/busybox.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: iscsi-pvc-pod
+  name: iscsi-pv-pod1
+spec:
+  containers:
+  - name: iscsi-pv-busybox
+    image: busybox
+    command: ["sleep", "60000"]
+    volumeMounts:
+    - name: iscsi-vol1
+      mountPath: /var/lib/busybox
+      readOnly: false
+  volumes:
+  - name: iscsi-vol1
+    persistentVolumeClaim:
+      claimName: myclaim


### PR DESCRIPTION
# Выполнено ДЗ №

 - [*] Основное ДЗ
 - [*] Задание со *

## Домашняя работа 12 (kubernetes-storage)

- Подготовим кластер k1s из 2 нод:
```console
git clone https://github.com/maniaque/k1s.git
cd k1s/vagrant/twin/
vagrant up
vagrant ssh -c 'cat /home/vagrant/.kube/config' > ~/.kube/config
```
- Установим CSI Host Path Driver:
```console
git clone https://github.com/kubernetes-csi/csi-driver-host-path.git
./csi-crd_deploy.sh
./csi-driver-host-path/deploy/kubernetes-1.18/deploy.sh
```
- Применим манифесты
```console
$ kubectl apply -f ./hw/csi-storageclass.yaml -f ./hw/csi-pvc.yaml -f ./hw/csi-app.yaml
storageclass.storage.k8s.io/csi-hostpath-sc created
persistentvolumeclaim/storage-pvc created
pod/storage-pod created
```
- Запишем данные в volume
```console
$ kubectl exec -it storage-pod /bin/sh
# touch /data/hello-world    
# ls -la /data
total 8
drwxr-xr-x 2 root root 4096 Nov 11 15:19 .
drwxr-xr-x 1 root root 4096 Nov 11 15:17 ..
-rw-r--r-- 1 root root    0 Nov 11 15:19 hello-world
```
- Создадим снапшот
```console
kubectl apply -f hw/csi-snapshot.yaml
volumesnapshot.snapshot.storage.k8s.io/csi-snapshot created
```
- Удалим pod, pv, pvс
```console
kubectl delete -f ./hw/csi-app.yaml
pod "storage-pod" deleted
kubectl delete -f ./hw/csi-pvc.yaml
persistentvolumeclaim "storage-pvc" deleted

kubectl get pvc
No resources found in default namespace.
kubectl get pv
No resources found in default namespace.
```

- Восстановимся из snapshot'а
```
kubectl apply -f ./hw/csi-restore.yaml
```
- Восстанавливаем pod и проверяем данные
```
kubectl apply -f ./hw/csi-app.yaml
```
```console
$ kubectl exec storage-pod -- ls -la /data
total 8
drwxr-xr-x 2 root root 4096 Nov 11 15:19 .
drwxr-xr-x 1 root root 4096 Nov 11 15:17 ..
-rw-r--r-- 1 root root    0 Nov 11 15:19 hello-world
```

### Развернуть k8s-кластер, к которому добавить хранилище на iSCSI | Задание со ⭐

Разворачиваем дополнительную виртуалку на Ubuntu 20.04. Так как для основного задания использовался vagrant,то добавлем общий сетевой итерфейс, через который будем ходить на iscsi. Дополнительно устанавливаем необходимые пакеты и готовим lvm:

```console
apt update && apt -y install targetcli-fb
parted -s /dev/sdb mklabel msdos
parted -s /dev/sdb unit mib mkpart primary 1 100% set 1 lvm on
pvcreate /dev/sdb1
vgcreate vg-scsi /dev/sdb1
lvcreate -L1024 -n lv1 vg-scsi
```

Производим первоначальную настройку iscsi и нарезаем LUN'и, настраиваем ACL под мастера и ноду k1s

```console
root@uiscsi:~# targetcli
Warning: Could not load preferences file /root/.targetcli/prefs.bin.
targetcli shell version 2.1.fb43
Copyright 2011-2013 by Datera, Inc and others.
For help on commands, type 'help'.

/> ls
o- / ......................................................................................................................... [...]
  o- backstores .............................................................................................................. [...]
  | o- block .................................................................................................. [Storage Objects: 0]
  | o- fileio ................................................................................................. [Storage Objects: 0]
  | o- pscsi .................................................................................................. [Storage Objects: 0]
  | o- ramdisk ................................................................................................ [Storage Objects: 0]
  o- iscsi ............................................................................................................ [Targets: 0]
  o- loopback ......................................................................................................... [Targets: 0]
  o- vhost ............................................................................................................ [Targets: 0]
/> /backstores/block create storage1 /dev/vg-scsi/lv1
Created block storage object storage1 using /dev/vg-scsi/lv1.
/> /iscsi create
Created target iqn.2003-01.org.linux-iscsi.uiscsi.x8664:sn.d18ce9e73eff.
Created TPG 1.
Global pref auto_add_default_portal=true
Created default portal listening on all IPs (0.0.0.0), port 3260.
/> /iscsi/
/iscsi> ls
o- iscsi .............................................................................................................. [Targets: 1]
  o- iqn.2003-01.org.linux-iscsi.uiscsi.x8664:sn.d18ce9e73eff ............................................................ [TPGs: 1]
    o- tpg1 ................................................................................................. [no-gen-acls, no-auth]
      o- acls ............................................................................................................ [ACLs: 0]
      o- luns ............................................................................................................ [LUNs: 0]
      o- portals ...................................................................................................... [Portals: 1]
        o- 0.0.0.0:3260 ....................................................................................................... [OK]
/iscsi> iqn.2003-01.org.linux-iscsi.uiscsi.x8664:sn.d18ce9e73eff/tpg1
/iscsi/iqn.20...e9e73eff/tpg1> luns/ create /backstores/block/storage1
Created LUN 0.
/iscsi/iqn.20...e9e73eff/tpg1> set attribute authentication=0
Parameter authentication is now '0'.
/iscsi/iqn.20...e9e73eff/tpg1> acls/
/iscsi/iqn.20...eff/tpg1/acls> create iqn.2020-11.local.kernel:k1s-node
Created Node ACL for iqn.2020-11.local.kernel:k1s-node
Created mapped LUN 0.
/iscsi/iqn.20...eff/tpg1/acls> create iqn.2020-11.local.kernel:k1s-master
Created Node ACL for iqn.2020-11.local.kernel:k1s-master
Created mapped LUN 0.
/iscsi/iqn.20...eff/tpg1/acls> cd ..
/iscsi/iqn.20...e9e73eff/tpg1> set parameter AuthMethod=None
Parameter AuthMethod is now 'None'.
/iscsi/iqn.20...e9e73eff/tpg1> set attribute authentication=0
Parameter authentication is now '0'.
/iscsi/iqn.20...e9e73eff/tpg1> ls
o- tpg1 ..................................................................................................... [no-gen-acls, no-auth]
  o- acls ................................................................................................................ [ACLs: 2]
  | o- iqn.2020-11.local.kernel:k1s-master ........................................................................ [Mapped LUNs: 1]
  | | o- mapped_lun0 .................................................................................... [lun0 block/storage1 (rw)]
  | o- iqn.2020-11.local.kernel:k1s-node .......................................................................... [Mapped LUNs: 1]
  |   o- mapped_lun0 .................................................................................... [lun0 block/storage1 (rw)]
  o- luns ................................................................................................................ [LUNs: 1]
  | o- lun0 .................................................................................... [block/storage1 (/dev/vg-scsi/lv1)]
  o- portals .......................................................................................................... [Portals: 1]
    o- 0.0.0.0:3260 ........................................................................................................... [OK]
/iscsi/iqn.20...e9e73eff/tpg1> cd ../../..
/> saveconfig
Last 10 configs saved in /etc/rtslib-fb-target/backup.
Configuration saved to /etc/rtslib-fb-target/saveconfig.json
/> exit
Global pref auto_save_on_exit=true
Last 10 configs saved in /etc/rtslib-fb-target/backup.
Configuration saved to /etc/rtslib-fb-target/saveconfig.json
```

На нодах устанавилваем пакет **open-iscsi** и провзодим настроку файла конфига **/etc/iscsi/initiatorname.iscsi** соответвенно вышеописанным настройкам

```console
root@k1s-node:~# cat /etc/iscsi/initiatorname.iscsi
InitiatorName=iqn.2020-11.local.kernel:k1s-node
```
```console
root@k1s-master:~# cat /etc/iscsi/initiatorname.iscsi
InitiatorName=iqn.2020-11.local.kernel:k1s-master
```

Проверяем доступность:
```console
root@k1s-node:~# iscsiadm -m discovery -t sendtargets -p 192.168.33.254
192.168.33.254:3260,1 iqn.2003-01.org.linux-iscsi.uscsi.x8664:sn.0875d5377b93
root@k1s-node:~# iscsiadm -m node --login
Logging in to [iface: default, target: iqn.2003-01.org.linux-iscsi.uscsi.x8664:sn.0875d5377b93, portal: 192.168.33.254,3260] (multiple)
Login to [iface: default, target: iqn.2003-01.org.linux-iscsi.uscsi.x8664:sn.0875d5377b93, portal: 192.168.33.254,3260] successful.
root@k1s-node:~# iscsiadm -m node --logout
Logging out of session [sid: 1, target: iqn.2003-01.org.linux-iscsi.uscsi.x8664:sn.0875d5377b93, portal: 192.168.33.254,3260]
Logout of [sid: 1, target: iqn.2003-01.org.linux-iscsi.uscsi.x8664:sn.0875d5377b93, portal: 192.168.33.254,3260] successful.
```

Применяем манифесты:
```console
kubectl apply -f busbox-pv.yaml -f busbox-pvc.yaml -f busbox.yaml
persistentvolume/iscsi-pv created
persistentvolumeclaim/myclaim created
pod/iscsi-pv-pod1 created
```
***busbox-pv.yaml***
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: iscsi-pv
spec:
  capacity:
    storage: 1Gi
  accessModes:
    - ReadWriteOnce
  iscsi:
     targetPortal: 192.168.33.254
     iqn: iqn.2003-01.org.linux-iscsi.uiscsi.x8664:sn.d18ce9e73eff
     lun: 0
     fsType: 'ext4'
     readOnly: false
```
***busbox-pvc.yaml***
```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: myclaim
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
```
***busbox.yaml***
```
apiVersion: v1
kind: Pod
metadata:
  labels:
    test: iscsi-pvc-pod
  name: iscsi-pv-pod1
spec:
  containers:
  - name: iscsi-pv-busybox
    image: busybox
    command: ["sleep", "60000"]
    volumeMounts:
    - name: iscsi-vol1
      mountPath: /var/lib/busybox
      readOnly: false
  volumes:
  - name: iscsi-vol1
    persistentVolumeClaim:
      claimName: myclaim
```

Записываем данные в pod:
```console
$ kubectl exec -it iscsi-pv-pod1 /bin/sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
/ # echo "ISCSI TEST!" > /var/lib/busybox/test.txt
/ # ls -la /var/lib/busybox/
total 28
drwxr-xr-x    3 root     root          4096 Nov 11 12:54 .
drwxr-xr-x    3 root     root          4096 Nov 11 12:54 ..
drwx------    2 root     root         16384 Nov 11 12:54 lost+found
-rw-r--r--    1 root     root             7 Nov 11 12:54 test.txt
/ # 
```

Идем на хранилище для создания snapshot'a

```console
root@uscsi:~# lvcreate -L 500MB -s -n sn01 /dev/mapper/vg--scsi-lv1
  Logical volume "sn01" created.
````

Удаляем данные на вольюме pod'a

```console
$ kubectl exec -it iscsi-pv-pod1 /bin/sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
/ # rm /var/lib/busybox/test.txt
/ # ls -la /var/lib/busybox/
total 24
drwxr-xr-x    3 root     root          4096 Nov 11 12:57 .
drwxr-xr-x    3 root     root          4096 Nov 11 12:54 ..
drwx------    2 root     root         16384 Nov 11 12:54 lost+found
```

Удаляем pvc, pv, pod

```console
kubectl delete pod iscsi-pv-pod1
pod "iscsi-pv-pod1" deleted

kubectl delete pvc myclaim
persistentvolumeclaim "myclaim" deleted

iscsi kubectl delete pv iscsi-pv
persistentvolume "iscsi-pv" deleted
```

Идем на хранилище и удаляем блочное устройство iscsi (без удаления снапшот не раскатается из-за занятого lvm)

```console
# targetcli
targetcli shell version 2.1.fb43
Copyright 2011-2013 by Datera, Inc and others.
For help on commands, type 'help'.

/> backstores/block delete storage1
Deleted storage object storage1.
/> saveconfig
Last 10 configs saved in /etc/rtslib-fb-target/backup.
Configuration saved to /etc/rtslib-fb-target/saveconfig.json
/> exit
Global pref auto_save_on_exit=true
Last 10 configs saved in /etc/rtslib-fb-target/backup.
Configuration saved to /etc/rtslib-fb-target/saveconfig.json
```

Мержим снапшот lvm:

```console
# lvconvert --merge /dev/vg-scsi/sn01 
  Merging of volume vg-scsi/sn01 started.
  vg-scsi/lv1: Merged: 100,00%
```

Восстанавливаем блочное устройство iscsi:

```console
# targetcli
targetcli shell version 2.1.fb43
Copyright 2011-2013 by Datera, Inc and others.
For help on commands, type 'help'.

/> /backstores/block create storage1 /dev/vg-scsi/lv1
Created block storage object storage1 using /dev/vg-scsi/lv1.
/> /iscsi/iqn.2003-01.org.linux-iscsi.uiscsi.x8664:sn.d18ce9e73eff/tpg1/
/iscsi/iqn.20...e9e73eff/tpg1> luns/ create /backstores/block/storage1
Created LUN 0.
Created LUN 0->0 mapping in node ACL iqn.2020-11.local.kernel:k1s-node
Created LUN 0->0 mapping in node ACL iqn.2020-11.local.kernel:k1s-master
/iscsi/iqn.20...e9e73eff/tpg1> cd /
/> saveconfig
Last 10 configs saved in /etc/rtslib-fb-target/backup.
Configuration saved to /etc/rtslib-fb-target/saveconfig.json
/> exit
Global pref auto_save_on_exit=true
Last 10 configs saved in /etc/rtslib-fb-target/backup.
Configuration saved to /etc/rtslib-fb-target/saveconfig.json
```

Снова применим манифесты:
```console
kubectl apply -f busbox-pv.yaml -f busbox-pvc.yaml -f busbox.yaml
persistentvolume/iscsi-pv created
persistentvolumeclaim/myclaim created
pod/iscsi-pv-pod1 created

Проверяем наличие удаленных данных:
```console
$ kubectl exec -it iscsi-pv-pod1 /bin/sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
/ # cat /var/lib/busybox/test.txt 
ISCSI TEST!
```

## PR checklist:
 - [*] Выставлен label с темой домашнего задания
