### PR TITLE
Add hw14 files

### DIFF
--- a/kubernetes-production-clusters/inventory.ini
+++ b/kubernetes-production-clusters/inventory.ini
@@ -1,0 +1,23 @@
+[all]
+master1 ansible_host=34.90.236.93  ip=10.164.15.195 etcd_member_name=etcd1
+node1 ansible_host=34.90.85.26    # ip=10.3.0.1 etcd_member_name=etcd1
+node2 ansible_host=34.90.18.167    # ip=10.3.0.1 etcd_member_name=etcd1
+node3 ansible_host=34.90.214.66    # ip=10.3.0.1 etcd_member_name=etcd1
+
+[kube-master]
+master1
+
+[etcd]
+master1
+
+[kube-node]
+node1
+node2
+node3
+
+[calico-rr]
+
+[k8s-cluster:children]
+kube-master
+kube-node
+calico-rr

--- a/kubernetes-production-clusters/inventory_3m2n.ini
+++ b/kubernetes-production-clusters/inventory_3m2n.ini
@@ -1,0 +1,27 @@
+[all]
+master-1 ansible_host=34.90.236.93  ip=10.164.15.199 etcd_member_name=etcd1
+master-2 ansible_host=34.90.85.26  ip=10.164.15.200 etcd_member_name=etcd2
+master-3 ansible_host=34.90.18.167  ip=10.164.15.201 etcd_member_name=etcd3
+node-1 ansible_host=34.90.209.100   # ip=10.3.0.1 etcd_member_name=etcd1
+node-2 ansible_host=34.90.214.66    # ip=10.3.0.1 etcd_member_name=etcd1
+
+[kube-master]
+master-1
+master-2
+master-3
+
+[etcd]
+master-1
+master-2
+master-3
+
+[kube-node]
+node-1
+node-2
+
+[calico-rr]
+
+[k8s-cluster:children]
+kube-master
+kube-node
+calico-rr


### PR DESCRIPTION
# Выполнено ДЗ №

 - [*] Основное ДЗ
 - [*] Задание со *

## Домашняя работа 14 (kubernetes-production-clusters)

### Разворачивание и обновление кластера k8s (kubeadm)

- Создаем 4 ноды с ubuntu 18.04 LTS:

```console
$ gcloud compute instances create master --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-2
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/master].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP  STATUS
master  europe-west4-c  n1-standard-2               10.164.0.63  34.90.85.26  RUNNING
$ gcloud compute instances create node-1 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1 
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/node-1].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
node-1  europe-west4-c  n1-standard-1               10.164.15.192  34.90.236.93  RUNNING
$ Createdgcloud compute instances create node-2 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1
Createdgcloud: команда не найдена
$ gcloud compute instances create node-2 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/node-2].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
node-2  europe-west4-c  n1-standard-1               10.164.15.193  34.90.214.66  RUNNING
$ gcloud compute instances create node-3 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/node-3].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
node-3  europe-west4-c  n1-standard-1               10.164.15.194  34.90.18.167  RUNNING
```

- Отключаем swap

```console
$ gcloud beta compute ssh master
$ sudo swapoff -a
$ gcloud beta compute ssh node-1
$ sudo swapoff -a
$ gcloud beta compute ssh node-2
$ sudo swapoff -a
$ gcloud beta compute ssh node-3
$ sudo swapoff -a
```

- Включаем маршрутизацию пакетов на всех нодах и применяем её.

```console
# cat > /etc/sysctl.d/99-kubernetes-cri.conf <<EOF
net.bridge.bridge-nf-call-iptables = 1
net.ipv4.ip_forward = 1
net.bridge.bridge-nf-call-ip6tables = 1
EOF
# sysctl --system
```

- Добавим ключ официального репозитария docker, сам репозитарий и установим из него необходимые пакеты

```console
# apt update && apt-get install -y \
    apt-transport-https ca-certificates curl software-properties-common gnupg2
# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 
# add-apt-repository \
            "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
# apt update && apt-get install -y \
          containerd.io=1.2.13-1 \
          docker-ce=5:19.03.8~3-0~ubuntu-$(lsb_release -cs) \
          docker-ce-cli=5:19.03.8~3-0~ubuntu-$(lsb_release -cs)
# cat > /etc/docker/daemon.json <<EOF
{
    "exec-opts": ["native.cgroupdriver=systemd"],
    "log-driver": "json-file",
    "log-opts": {
        "max-size": "100m"
     },
    "storage-driver": "overlay2"
}
EOF
# mkdir -p /etc/systemd/system/docker.service.d && systemctl daemon-reload && systemctl restart docker
```

- Установим kubeadm, kubectl, kubelet на всех нодах

```console
# apt update && apt install -y apt-transport-https curl
# curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
# cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
deb https://apt.kubernetes.io/ kubernetes-xenial main
EOF
# apt update && apt install -y kubelet=1.17.4-00 kubeadm=1.17.4-00 kubectl=1.17.4-00
```

- Создаем кластер

```console
# kubeadm init --pod-network-cidr=192.168.0.0/24
...
hen you can join any number of worker nodes by running the following on each as root:

kubeadm join 10.164.0.63:6443 --token 3zca56.pkgnfs2f5ddnu8vt \
    --discovery-token-ca-cert-hash sha256:c2658f8d4f01bf2ceed86bc067fcf7ba57e3ec819596e27abadb55d70b940aac
```

- Копируем конфиг kubectl и проверяем

```console
# mkdir -p $HOME/.kube
# sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
# sudo chown $(id -u):$(id -g) $HOME/.kube/config
# kubectl get nodes 
NAME     STATUS     ROLES    AGE     VERSION
master   NotReady   master   4m15s   v1.17.4
```

- Устанавливаем сетевой плагин calico

```console
kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
```

- Подключаем worker-ноды

```console
# kubeadm token list
TOKEN                     TTL         EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
3zca56.pkgnfs2f5ddnu8vt   23h         2020-11-14T10:09:49Z   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token

# openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | \
  openssl dgst -sha256 -hex | sed 's/^.* //'
c2658f8d4f01bf2ceed86bc067fcf7ba57e3ec819596e27abadb55d70b940aac
# kubeadm join 10.164.0.63:6443 --token 3zca56.pkgnfs2f5ddnu8vt \
    --discovery-token-ca-cert-hash sha256:c2658f8d4f01bf2ceed86bc067fcf7ba57e3ec819596e27abadb55d70b940aac
# kubectl get nodes
NAME     STATUS   ROLES    AGE   VERSION
master   Ready    master   13m   v1.17.4
node-1   Ready    <none>   79s   v1.17.4
node-2   Ready    <none>   72s   v1.17.4
node-3   Ready    <none>   69s   v1.17.4
```

- Для демонстрации работы кластера запустим nginx

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 4
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.17.2
        ports:
        - containerPort: 80
```
```console
# kubectl apply -f deployment.yaml
# kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE   IP              NODE     NOMINATED NODE   READINESS GATES
nginx-deployment-c8fd555cc-6w6fm   1/1     Running   0          17s   192.168.0.65    node-2   <none>           <none>
nginx-deployment-c8fd555cc-jfbpl   1/1     Running   0          17s   192.168.0.193   node-3   <none>           <none>
nginx-deployment-c8fd555cc-lbd2b   1/1     Running   0          17s   192.168.0.66    node-2   <none>           <none>
nginx-deployment-c8fd555cc-wb59m   1/1     Running   0          17s   192.168.0.129   node-1   <none>           <none>
```

- Обновляем master-ноду до версии 1.18, анализируем версии.

```console
# apt update && apt-get install -y kubeadm=1.18.0-00 \
kubelet=1.18.0-00 kubectl=1.18.0-00
# kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE     IP              NODE     NOMINATED NODE   READINESS GATES
nginx-deployment-c8fd555cc-6w6fm   1/1     Running   0          3m43s   192.168.0.65    node-2   <none>           <none>
nginx-deployment-c8fd555cc-jfbpl   1/1     Running   0          3m43s   192.168.0.193   node-3   <none>           <none>
nginx-deployment-c8fd555cc-lbd2b   1/1     Running   0          3m43s   192.168.0.66    node-2   <none>           <none>
nginx-deployment-c8fd555cc-wb59m   1/1     Running   0          3m43s   192.168.0.129   node-1   <none>           <none>

# kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:56:30Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
# kubelet --version
Kubernetes v1.18.0
# kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.14", GitCommit:"f238f5142728be4033c37aa0ad69bf806090beae", GitTreeState:"clean", BuildDate:"2020-11-11T13:03:54Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
# kubectl describe pod kube-apiserver-master -n kube-system
Name:                 kube-apiserver-master
Namespace:            kube-system
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Node:                 master/10.164.0.63
Start Time:           Fri, 13 Nov 2020 10:09:50 +0000
Labels:               component=kube-apiserver
                      tier=control-plane
Annotations:          kubernetes.io/config.hash: 9cac50f26a161064521996c064f0e92a
                      kubernetes.io/config.mirror: 9cac50f26a161064521996c064f0e92a
                      kubernetes.io/config.seen: 2020-11-13T10:30:17.743884453Z
                      kubernetes.io/config.source: file
Status:               Running
IP:                   10.164.0.63
IPs:
  IP:           10.164.0.63
Controlled By:  Node/master
Containers:
  kube-apiserver:
    Container ID:  docker://728288b5692e9a164b661bb85abdd7b902758fa260dfa33e280ddde083570a68
    Image:         k8s.gcr.io/kube-apiserver:v1.17.14
    Image ID:      docker-pullable://k8s.gcr.io/kube-apiserver@sha256:ad3a0ff8f8ef783e097566f35bf40087d8a454abd37a6c78afead04f9b0c1a17
    Port:          <none>
    Host Port:     <none>
    Command:
      kube-apiserver
      --advertise-address=10.164.0.63
      --allow-privileged=true
      --authorization-mode=Node,RBAC
      --client-ca-file=/etc/kubernetes/pki/ca.crt
      --enable-admission-plugins=NodeRestriction
      --enable-bootstrap-token-auth=true
      --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
      --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt
      --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
      --etcd-servers=https://127.0.0.1:2379
      --insecure-port=0
      --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
      --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key
      --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
      --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt
      --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
      --requestheader-allowed-names=front-proxy-client
      --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
      --requestheader-extra-headers-prefix=X-Remote-Extra-
      --requestheader-group-headers=X-Remote-Group
      --requestheader-username-headers=X-Remote-User
      --secure-port=6443
      --service-account-key-file=/etc/kubernetes/pki/sa.pub
      --service-cluster-ip-range=10.96.0.0/12
      --tls-cert-file=/etc/kubernetes/pki/apiserver.crt
      --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
    State:          Running
      Started:      Fri, 13 Nov 2020 10:30:22 +0000
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:        250m
    Liveness:     http-get https://10.164.0.63:6443/healthz delay=15s timeout=15s period=10s #success=1 #failure=8
    Environment:  <none>
    Mounts:
      /etc/ca-certificates from etc-ca-certificates (ro)
      /etc/kubernetes/pki from k8s-certs (ro)
      /etc/ssl/certs from ca-certs (ro)
      /usr/local/share/ca-certificates from usr-local-share-ca-certificates (ro)
      /usr/share/ca-certificates from usr-share-ca-certificates (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  ca-certs:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/ssl/certs
    HostPathType:  DirectoryOrCreate
  etc-ca-certificates:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/ca-certificates
    HostPathType:  DirectoryOrCreate
  k8s-certs:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/kubernetes/pki
    HostPathType:  DirectoryOrCreate
  usr-local-share-ca-certificates:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/local/share/ca-certificates
    HostPathType:  DirectoryOrCreate
  usr-share-ca-certificates:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/share/ca-certificates
    HostPathType:  DirectoryOrCreate
QoS Class:         Burstable
Node-Selectors:    <none>
Tolerations:       :NoExecute
Events:
  Type    Reason   Age    From             Message
  ----    ------   ----   ----             -------
  Normal  Pulled   3m25s  kubelet, master  Container image "k8s.gcr.io/kube-apiserver:v1.17.14" already present on machine
  Normal  Created  3m25s  kubelet, master  Created container kube-apiserver
  Normal  Started  3m24s  kubelet, master  Started container kube-apiserver
```
**kubeadm: v1.18.0**

**kubelet: v1.18.0**

**kubectl client v1.18.0 server v1.17.14**

**api-server: v1.17.14**

- Обновим остальные компоненты кластера

```console
# kubeadm upgrade plan
# kubeadm upgrade apply v1.18.0
# kubectl get nodes
NAME     STATUS   ROLES    AGE   VERSION
master   Ready    master   32m   v1.18.0
node-1   Ready    <none>   20m   v1.17.4
node-2   Ready    <none>   19m   v1.17.4
node-3   Ready    <none>   19m   v1.17.4
```
**kubeadm: v1.18.0**

**kubelet: v1.18.0**

**kubectl client v1.18.0 server v1.18.0**

**api-server: v1.18.0**

- Выводим worker-ноду из планирования и обновляем и возвращаем в работу.

```console
root@master:~# kubectl drain node-1 --ignore-daemonsets
root@master:~# kubectl get nodes -o wide
NAME     STATUS                     ROLES    AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
master   Ready                      master   45m   v1.18.0   10.164.0.63     <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
node-1   Ready,SchedulingDisabled   <none>   32m   v1.17.4   10.164.15.192   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
node-2   Ready                      <none>   32m   v1.17.4   10.164.15.193   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
node-3   Ready                      <none>   32m   v1.17.4   10.164.15.194   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
root@node-1:~# apt install -y kubelet=1.18.0-00 kubeadm=1.18.0-00
root@node-1:~# systemctl restart kubelet
root@master:~# kubectl get nodes -o wide
NAME     STATUS                     ROLES    AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
master   Ready                      master   47m   v1.18.0   10.164.0.63     <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
node-1   Ready,SchedulingDisabled   <none>   34m   v1.18.0   10.164.15.192   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
node-2   Ready                      <none>   34m   v1.17.4   10.164.15.193   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
node-3   Ready                      <none>   34m   v1.17.4   10.164.15.194   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.8
root@master:~# kubectl uncordon node-1
```

- Повторяем действия с оставшимися нодами

```console
root@master# kubectl drain node-2 --ignore-daemonsets
root@node-2# apt install -y kubelet=1.18.0-00 kubeadm=1.18.0-00
root@node-2# systemctl restart kubelet
root@master# kubectl uncordon node-2
root@master# kubectl drain node-3 --ignore-daemonsets
root@node-3# apt install -y kubelet=1.18.0-00 kubeadm=1.18.0-00
root@node-3# systemctl restart kubelet
root@master# kubectl uncordon node-3
root@master# kubectl get nodes
NAME     STATUS   ROLES    AGE   VERSION
master   Ready    master   54m   v1.18.0
node-1   Ready    <none>   41m   v1.18.0
node-2   Ready    <none>   41m   v1.18.0
node-3   Ready    <none>   41m   v1.18.0
```

### Kubespray

- Создаем ноды и производим обмен ключами ssh и узнаем внешние ip виртуалок

```console
gcloud compute instances create master --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-2 && \
> gcloud compute instances create node-1 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1 && \
> gcloud compute instances create node-2 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1 && \
> gcloud compute instances create node-3 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/master].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
master  europe-west4-c  n1-standard-2               10.164.15.195  34.90.236.93  RUNNING
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP  STATUS
node-1  europe-west4-c  n1-standard-1               10.164.15.196  34.90.85.26  RUNNING
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
node-2  europe-west4-c  n1-standard-1               10.164.15.197  34.90.18.167  RUNNING
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
node-3  europe-west4-c  n1-standard-1               10.164.15.198  34.90.214.66  RUNNING
```
```console
$ gcloud beta compute ssh master
$ gcloud beta compute ssh node-1
$ gcloud beta compute ssh node-2
$ gcloud beta compute ssh node-3
```
```console
$ for name in master node-1 node-2 node-3; do echo $name:; gcloud compute instances describe $name | grep natIP; done
master:
    natIP: 34.90.236.93
node-1:
    natIP: 34.90.85.26
node-2:
    natIP: 34.90.18.167
node-3:
    natIP: 34.90.214.66
```

- Устанавливаем
```console
# получение kubespray
git clone https://github.com/kubernetes-sigs/kubespray.git
# установка зависимостей
sudo pip3 install -r requirements.txt
# копирование примера конфига в отдельную директорию
cp -rfp inventory/sample inventory/mycluster
```

- Правим файл ***inventory/mycluster/inventory.ini***
```ini
[all]
master1 ansible_host=34.90.236.93  ip=10.164.15.195 etcd_member_name=etcd1
node1 ansible_host=34.90.85.26    # ip=10.3.0.1 etcd_member_name=etcd1
node2 ansible_host=34.90.18.167    # ip=10.3.0.1 etcd_member_name=etcd1
node3 ansible_host=34.90.214.66    # ip=10.3.0.1 etcd_member_name=etcd1

[kube-master]
master1

[etcd]
master1

[kube-node]
node1
node2
node3

[calico-rr]

[k8s-cluster:children]
kube-master
kube-node
calico-rr
```

- Применяем
```console
$ ansible-playbook -i inventory/mycluster/inventory.ini --become --become-user=root \
    --user=dimon --key-file="~/.ssh/google_compute_engine" cluster.yml
```

- Логинимся на матер-ноду и проверяем
```console
root@master1:~# kubectl get node -o wide
NAME      STATUS   ROLES    AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
master1   Ready    master   9m5s    v1.19.3   10.164.15.195   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
node1     Ready    <none>   7m54s   v1.19.3   10.164.15.196   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
node2     Ready    <none>   7m54s   v1.19.3   10.164.15.197   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
node3     Ready    <none>   7m53s   v1.19.3   10.164.15.198   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
```

### Задание со 🌟

- Создаем ноды и производим обмен ключами ssh.

```console
gcloud compute instances create master-1 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-2 && \
gcloud compute instances create master-2 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-2 && \
gcloud compute instances create master-3 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-2 && \
gcloud compute instances create node-1 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1 && \
gcloud compute instances create node-2 --image-family ubuntu-minimal-1804-lts --image-project ubuntu-os-cloud --machine-type=n1-standard-1
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/master-1].
NAME      ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
master-1  europe-west4-c  n1-standard-2               10.164.15.199  34.90.236.93  RUNNING
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/master-2].
NAME      ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP  STATUS
master-2  europe-west4-c  n1-standard-2               10.164.15.200  34.90.85.26  RUNNING
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/master-3].
NAME      ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
master-3  europe-west4-c  n1-standard-2               10.164.15.201  34.90.18.167  RUNNING
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/node-1].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP    STATUS
node-1  europe-west4-c  n1-standard-1               10.164.15.202  34.90.209.100  RUNNING
Created [https://www.googleapis.com/compute/v1/projects/project-otus-287811/zones/europe-west4-c/instances/node-2].
NAME    ZONE            MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP   STATUS
node-2  europe-west4-c  n1-standard-1               10.164.15.203  34.90.214.66  RUNNING
```
```console
$ gcloud beta compute ssh master-1
$ gcloud beta compute ssh master-2
$ gcloud beta compute ssh master-3
$ gcloud beta compute ssh node-1
$ gcloud beta compute ssh node-2
```

- Правим ***inventory.ini*** (inventory_3m2n.ini в каталоге)
```ini
[all]
master-1 ansible_host=34.90.236.93  ip=10.164.15.199 etcd_member_name=etcd1
master-2 ansible_host=34.90.85.26  ip=10.164.15.200 etcd_member_name=etcd2
master-3 ansible_host=34.90.18.167  ip=10.164.15.201 etcd_member_name=etcd3
node-1 ansible_host=34.90.209.100   # ip=10.3.0.1 etcd_member_name=etcd1
node-2 ansible_host=34.90.214.66    # ip=10.3.0.1 etcd_member_name=etcd1

[kube-master]
master-1
master-2
master-3

[etcd]
master-1
master-2
master-3

[kube-node]
node-1
node-2

[calico-rr]

[k8s-cluster:children]
kube-master
kube-node
calico-rr
```

- Применяем
```console
$ ansible-playbook -i inventory/mycluster/inventory.ini --become --become-user=root \
    --user=dimon --key-file="~/.ssh/google_compute_engine" cluster.yml

- - Логинимся на маcтер-ноду и проверяем
```console
root@master-2:~# kubectl get node -o wide
NAME       STATUS   ROLES    AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
master-1   Ready    master   4m56s   v1.19.3   10.164.15.199   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
master-2   Ready    master   4m27s   v1.19.3   10.164.15.200   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
master-3   Ready    master   4m26s   v1.19.3   10.164.15.201   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
node-1     Ready    <none>   3m14s   v1.19.3   10.164.15.202   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
node-2     Ready    <none>   3m14s   v1.19.3   10.164.15.203   <none>        Ubuntu 18.04.5 LTS   5.4.0-1029-gcp   docker://19.3.13
```

## PR checklist:
 - [*] Выставлен label с темой домашнего задания
